### PR TITLE
refactor/002/Changing structure of how the cache key is built

### DIFF
--- a/includes/Cache.php
+++ b/includes/Cache.php
@@ -15,6 +15,18 @@ class Cache
     private const DEFAULT_EXPIRATION = 86400; // Default expiration time in seconds (1 day).
 
     /**
+     * Generates a unique cache key based on sign and date.
+     *
+     * @param string $sign The zodiac sign.
+     * @param string $date The date.
+     * @return string A unique cache key.
+     */
+    public function generateCacheKey(string $sign, string $date): string
+    {
+        return 'horoscope_' . strtolower($sign) . '_' . $date;
+    }
+
+    /**
      * Sets a cache entry with a specified key and expiration time.
      *
      * @param string $key Unique identifier for the cache.
@@ -67,7 +79,7 @@ class Cache
     public function deleteCache(string $key): void
     {
         $this->validateCacheKey($key);
-        
+
         if (delete_transient($key)) {
             error_log("Cache deleted for key: $key");
         } else {

--- a/includes/Shortcode.php
+++ b/includes/Shortcode.php
@@ -59,7 +59,7 @@ class Shortcode
             $atts
         );
 
-        $sign = !empty($atts['sign']) ? $atts['sign'] : get_option('horoscope_data')['selected_sign'] ?? self::DEFAULT_SIGN;         // Use the provided sign or the selected sign from options.
+        $sign = !empty($atts['sign']) ? $atts['sign'] : get_option('horoscope_data')['selected_sign'] ?? self::DEFAULT_SIGN; // Use the provided sign or the selected sign from options.
         $main_date = !empty($atts['date']) ? $atts['date'] : get_option('horoscope_data')['selected_date'] ?? date('Y-m-d'); // Use provided date or the selected date from options.
 
         // Validate the provided date format (YYYY-MM-DD) and use today if invalid.
@@ -75,7 +75,7 @@ class Shortcode
         ];
 
         // Generate a cache key based on the sign and main date for storing or retrieving cached horoscope data.
-        $cache_key = 'horoscope_' . $sign . '_' . $main_date;
+        $cache_key = $this->cache->generateCacheKey($sign, $main_date);
         $horoscope_data = $this->cache->getCache($cache_key);
 
         // If no data in cache, fetch it from the API.


### PR DESCRIPTION
- The cache key is built using in the Cache class, and moved out of the Shortcode class.
- Deactivation function now clears the cache from there